### PR TITLE
Fix string-path stubout and global Mox registry leak/contamination

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,9 @@ repos:
   hooks:
     - id: bandit
       args: [--exclude, test]
+      # bandit 1.7.0 imports pbr at runtime but does not pull it into the
+      # hook's isolated env on newer Python; install it explicitly.
+      additional_dependencies: ['pbr']
 - repo: https://github.com/timothycrosley/isort
   rev: 5.12.0
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+-   Fixed `stubout`/`stubout_class` raising `AttributeError` when given a string object path together with a separate `attr_name`
+-   Fixed the global Mox instance registry leaking instances for the life of the process and re-verifying mocks from earlier tests, which could leak failures across unrelated tests; test teardown now clears the registry
+
 ## 1.4.1
 
 -   Fixed tests output when mocking builtin functions

--- a/mox/contextmanagers.py
+++ b/mox/contextmanagers.py
@@ -5,9 +5,13 @@ class Create:
         self.m = Mox()
 
     def __call__(self, class_to_mock, attrs=None):
+        # Re-register in case a previous test's teardown cleared the registry;
+        # mox.expect relies on this shared Mox being globally tracked.
+        type(self.m).track(self.m)
         return self.m.create_mock(class_to_mock, attrs)
 
     def any(self, description=None):
+        type(self.m).track(self.m)
         return self.m.create_mock_anything(description=description)
 
 

--- a/mox/helpers.py
+++ b/mox/helpers.py
@@ -122,7 +122,7 @@ def resolve_object(func):
             attr_name = kwargs.pop("attr_name")
 
         if isinstance(obj, str):
-            path = f"{obj.attr_name}" if attr_name else obj
+            path = f"{obj}.{attr_name}" if attr_name else obj
             obj, attr_name = import_object(path)
             obj = obj()
 

--- a/mox/mox.py
+++ b/mox/mox.py
@@ -88,25 +88,53 @@ class _MoxManagerMeta(type):
 
     def __call__(cls, *args, **kwargs):
         instance = super(_MoxManagerMeta, cls).__call__(*args, **kwargs)
-        cls._instances[id(instance)] = instance
+        cls.track(instance)
         return instance
 
+    def track(cls, instance):
+        """Register a Mox instance in the global registry.
+
+        Construction registers automatically; the context-manager singletons
+        (``mox.create``) also call this on each use so they re-register after a
+        test teardown has cleared the registry.
+        """
+        cls._instances[id(instance)] = instance
+
     def unset_stubs_for_id(cls, mox_id):
-        mox_instance = cls._instances[mox_id]
-        mox_instance.unset_stubs()
+        mox_instance = cls._instances.get(mox_id)
+        if mox_instance is not None:
+            mox_instance.unset_stubs()
 
     def global_unset_stubs(cls):
-        for mox_instance in cls._instances.values():
+        for mox_instance in list(cls._instances.values()):
             mox_instance.stubs.unset_all()
             mox_instance.stubs.smart_unset_all()
 
     def global_replay(cls):
-        for mox_instance in cls._instances.values():
+        for mox_instance in list(cls._instances.values()):
             mox_instance.replay_all()
 
     def global_verify(cls):
-        for mox_instance in cls._instances.values():
+        for mox_instance in list(cls._instances.values()):
             mox_instance.verify_all()
+
+    def reset_instances(cls):
+        """Forget all tracked Mox instances.
+
+        The context-manager API (``mox.expect``) and the pytest plugin operate
+        on every registered Mox instance via ``global_*``. Without clearing the
+        registry between tests, those instances would live for the whole
+        process (a memory leak) and - worse - a later test's global teardown
+        would re-verify mocks recorded by earlier tests, leaking failures
+        across unrelated tests. Test harnesses call this once their own
+        teardown is complete.
+        """
+        # Also drop accumulated mocks from the long-lived context-manager
+        # singletons (e.g. mox.create's shared Mox), so a prior test's leftover
+        # expectations can't be re-verified - and fail - during a later test.
+        for instance in cls._instances.values():
+            instance._mock_objects.clear()
+        cls._instances.clear()
 
 
 class Mox(metaclass=_MoxManagerMeta):

--- a/mox/testing/pytest_mox.py
+++ b/mox/testing/pytest_mox.py
@@ -23,6 +23,11 @@ def pytest_runtest_teardown(item):
     if cleanup_mox:
         mox_verify.unset_stubs()
 
-    mox.Mox.global_unset_stubs()
-    if cleanup_mox:
-        mox.Mox.global_verify()
+    try:
+        mox.Mox.global_unset_stubs()
+        if cleanup_mox:
+            mox.Mox.global_verify()
+    finally:
+        # Forget this test's Mox instances so they neither leak for the life of
+        # the process nor get re-verified during a later test's teardown.
+        mox.Mox.reset_instances()

--- a/mox/testing/unittest_mox.py
+++ b/mox/testing/unittest_mox.py
@@ -55,15 +55,20 @@ class MoxMetaTestBase(type):
             if stubout_obj and isinstance(stubout_obj, stubbingout.StubOutForTesting):
                 cleanup_stubout = True
             try:
-                func(self, *args, **kwargs)
-            finally:
+                try:
+                    func(self, *args, **kwargs)
+                finally:
+                    if cleanup_mox:
+                        mox_obj.unset_stubs()
+                    if cleanup_stubout:
+                        stubout_obj.unset_all()
+                        stubout_obj.smart_unset_all()
                 if cleanup_mox:
-                    mox_obj.unset_stubs()
-                if cleanup_stubout:
-                    stubout_obj.unset_all()
-                    stubout_obj.smart_unset_all()
-            if cleanup_mox:
-                mox_obj.verify_all()
+                    mox_obj.verify_all()
+            finally:
+                # Don't let this test's Mox instances linger in the global
+                # registry, where they would leak and contaminate later tests.
+                Mox.reset_instances()
 
         new_method.__name__ = func.__name__
         new_method.__doc__ = func.__doc__

--- a/test/pytest_mox_test.py
+++ b/test/pytest_mox_test.py
@@ -1,0 +1,63 @@
+# Python imports
+import unittest
+
+# Internal imports
+import mox
+from mox.testing import pytest_mox
+
+
+class _FakeRequest:
+    """Minimal stand-in for a pytest request object."""
+
+    def __init__(self, mox_obj):
+        self._mox_obj = mox_obj
+
+    def getfixturevalue(self, name):
+        assert name == "mox_verify"
+        return self._mox_obj
+
+
+class _FakeItem:
+    def __init__(self, funcargs):
+        self.funcargs = funcargs
+
+
+class PytestPluginTeardownTest(unittest.TestCase):
+    """Exercise the pytest plugin's teardown hook directly."""
+
+    def tearDown(self):
+        # Make sure we never leak instances into other tests.
+        mox.Mox.reset_instances()
+
+    def test_teardown_with_mox_verify_fixture_unsets_and_verifies(self):
+        """When the mox_verify fixture yields a Mox, teardown must unset its
+        stubs, verify it, and clear the global registry."""
+
+        mox_obj = mox.Mox()
+        mocked = mox_obj.create_mock_anything()
+        mocked.do_something()  # record an expectation
+        mox.replay(mocked)
+        mocked.do_something()  # satisfy it
+
+        item = _FakeItem({"request": _FakeRequest(mox_obj)})
+
+        # Should run global_unset_stubs + global_verify (cleanup_mox branch)
+        # without raising, then clear the registry in the finally block.
+        pytest_mox.pytest_runtest_teardown(item)
+
+        self.assertEqual(len(mox.Mox._instances), 0)
+
+    def test_teardown_without_request_still_clears_registry(self):
+        """Teardown for a test that uses no fixtures must still clear the
+        global registry (and not raise)."""
+
+        mox.Mox()  # registered in the global registry
+        item = _FakeItem({})
+
+        pytest_mox.pytest_runtest_teardown(item)
+
+        self.assertEqual(len(mox.Mox._instances), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two correctness fixes found while auditing the codebase.

### 1. `resolve_object` string-path bug (`mox/helpers.py`)
The import path was built as `f"{obj.attr_name}"` — that's attribute access on a `str`, not interpolation — so calling `stubout`/`stubout_class` with a string object path **and** a separate `attr_name` raised `AttributeError: 'str' object has no attribute 'attr_name'`.

```python
m.stubout(obj="os.path", attr_name="exists")  # was: AttributeError
```

Fixed to `f"{obj}.{attr_name}"`. The single-string form (`stubout("os.getcwd")`) already worked because it took the `else` branch, which is why tests didn't catch it.

### 2. Global Mox registry leak + cross-test contamination (`mox/mox.py`)
`_MoxManagerMeta` stored **every** `Mox()` ever created in a class-level dict and never released it. Combined with the pytest plugin calling `global_verify()`/`global_unset_stubs()` on every teardown, this:

- leaked every Mox instance for the life of the process, and
- re-verified mocks from **earlier** tests on each teardown — so an incomplete or failed test that left an unsatisfied expectation could surface that failure during an unrelated **later** test's teardown.

**Fix:** added `Mox.reset_instances()` and call it from both teardown paths (the pytest plugin and the unittest metaclass) inside `finally` blocks, so each test's instances are forgotten once its own verification completes. The long-lived context-manager singleton (`mox.create`) re-registers its shared `Mox` on each use via a new `Mox.track()` classmethod, and `reset_instances()` also clears accumulated mocks so prior expectations can't bleed forward.

> Note: a `WeakValueDictionary`/`WeakSet` was considered but rejected — `id()`-keyed weak dicts are unsafe (recycled ids can evict live entries), and the context-manager API depends on instances persisting for the duration of a test, which weak refs break nondeterministically.

## Testing
- All 444 existing tests pass.
- Verified both repros directly: the string-path stubout now succeeds, and a test that leaves an unsatisfied expectation no longer contaminates a later unrelated test; the registry returns to 0 entries after teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)