### PR TITLE
Make mock objects and comparators hashable

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,9 @@ repos:
   hooks:
     - id: bandit
       args: [--exclude, test]
+      # bandit 1.7.0 imports pbr at runtime but does not pull it into the
+      # hook's isolated env on newer Python; install it explicitly.
+      additional_dependencies: ['pbr']
 - repo: https://github.com/timothycrosley/isort
   rev: 5.12.0
   hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+-   `MockObject`, `MockAnything` and `Comparator` instances are now hashable again, so mocks can be used as dict keys or set members by the code under test
+
 ## 1.4.1
 
 -   Fixed tests output when mocking builtin functions

--- a/mox/comparators.py
+++ b/mox/comparators.py
@@ -42,6 +42,11 @@ class Comparator:
     def __ne__(self, rhs):
         return not self.equals(rhs)
 
+    def __hash__(self):
+        # __eq__ is overridden, which otherwise makes comparators unhashable in
+        # Python 3.  Hash by identity so comparators can be used in sets/dicts.
+        return id(self)
+
 
 class Is(Comparator):
     """Comparison class used to check identity, instead of equality."""

--- a/mox/mox.py
+++ b/mox/mox.py
@@ -453,6 +453,17 @@ class MockAnything:
 
         return not self == rhs
 
+    def __hash__(self):
+        """Hash by identity.
+
+        __eq__ is overridden (and is value-based), which by default makes
+        instances unhashable in Python 3.  Mocks frequently stand in for
+        objects that code-under-test uses as dict keys or set members, so we
+        restore hashability using object identity - the same approach taken by
+        MockMethod.
+        """
+        return id(self)
+
     @property
     def _expect(self):
         # Internal imports
@@ -639,6 +650,10 @@ class MockObject(MockAnything, object):
             and self._replay_mode == rhs._replay_mode
             and self._expected_calls_queue == rhs._expected_calls_queue
         )
+
+    # Defining __eq__ resets __hash__ to None in this class, so restore the
+    # identity-based hash inherited from MockAnything.
+    __hash__ = MockAnything.__hash__
 
     def __setitem__(self, key, value):
         """Provide custom logic for mocking classes that support item

--- a/test/mox_test.py
+++ b/test/mox_test.py
@@ -415,6 +415,12 @@ class IsATest(unittest.TestCase):
         stringIO = io.StringIO()
         self.assertTrue(isA == stringIO)
 
+    def test_is_hashable(self):
+        """A comparator must remain hashable despite overriding __eq__."""
+        comparator = mox.IsA(str)
+        self.assertEqual(hash(comparator), id(comparator))
+        self.assertIn(comparator, {comparator})
+
 
 class IsAlmostTest(unittest.TestCase):
     """Verify IsAlmost correctly checks equality of floating point numbers."""
@@ -669,6 +675,14 @@ class MockAnythingTest(unittest.TestCase):
     def test_repr(self):
         """Calling repr on a MockAnything instance must work."""
         self.assertEqual("<MockAnything instance>", repr(self.mock_object))
+
+    def test_is_hashable(self):
+        """A MockAnything must be usable as a dict key / set member."""
+        other = mox.MockAnything()
+        self.assertEqual(hash(self.mock_object), id(self.mock_object))
+        mapping = {self.mock_object: 1, other: 2}
+        self.assertEqual(mapping[self.mock_object], 1)
+        self.assertIn(other, {self.mock_object, other})
 
     def test_can_mock_str(self):
         self.mock_object.__str__().returns("foo")
@@ -958,6 +972,14 @@ class MockObjectTest(unittest.TestCase):
     def setUp(self):
         self.mock_object = mox.MockObject(TestClass)
         self.mock = mox.Mox()
+
+    def test_is_hashable(self):
+        """A MockObject must be usable as a dict key / set member."""
+        other = mox.MockObject(TestClass)
+        self.assertEqual(hash(self.mock_object), id(self.mock_object))
+        mapping = {self.mock_object: 1, other: 2}
+        self.assertEqual(mapping[self.mock_object], 1)
+        self.assertIn(other, {self.mock_object, other})
 
     def test_description(self):
         self.assertEqual(self.mock_object._description, "TestClass")


### PR DESCRIPTION
## Summary

`MockAnything`, `MockObject`, and `Comparator` all override `__eq__`. In Python 3, defining `__eq__` without `__hash__` sets `__hash__` to `None`, making instances **unhashable**:

```python
m = mox.Mox()
mock = m.create_mock(SomeClass)
{mock: "value"}   # TypeError: unhashable type: 'MockObject'
{mock}            # TypeError
```

This breaks any code under test that legitimately uses an object as a dict key or set member — a common pattern — when a mock is substituted in.

## Fix

Restore identity-based hashing (`return id(self)`) — the same approach `MockMethod` already uses. Because each class that defines `__eq__` independently resets `__hash__`, the hash is added to `MockAnything`, re-pointed on `MockObject` (which defines its own `__eq__`), and added to the `Comparator` base.

Hashing by identity is the right choice here: mocks/comparators are identity-like in tests, and it matches the existing `MockMethod` behavior.

## Testing
- Added regression tests for `MockAnything`, `MockObject`, and `IsA` (comparator) hashability.
- Full suite passes: **447 tests** (444 existing + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)