### PR TITLE
CI: fix bandit pre-commit hook (install pbr)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,9 @@ repos:
   hooks:
     - id: bandit
       args: [--exclude, test]
+      # bandit 1.7.0 imports pbr at runtime but does not pull it into the
+      # hook's isolated env on newer Python; install it explicitly.
+      additional_dependencies: ['pbr']
 - repo: https://github.com/timothycrosley/isort
   rev: 5.12.0
   hooks:


### PR DESCRIPTION
## Summary

The `pre-commit` job fails on every PR because the pinned `bandit==1.7.0` crashes at import on the CI runner's Python 3.14:

```
ModuleNotFoundError: No module named 'pbr'
```

bandit 1.7.0 imports `pbr` at runtime, but pre-commit doesn't install it into the hook's isolated environment on newer Python. Adding `pbr` to the hook's `additional_dependencies` resolves it.

This is split out as a standalone fix so the infra change lives in one place; the other open fix PRs (#47, #48, #49) drop their copy and go green once this merges to `main` (their CI runs against the merge with the updated base).

## Testing
- `pre-commit run --all-files` passes locally (bandit env now initializes `bandit:pbr`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)