### PR TITLE
Release 1.5.0: finalize changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.5.0
 
 -   `MockObject`, `MockAnything` and `Comparator` instances are now hashable again, so mocks can be used as dict keys or set members by the code under test
 -   Fixed `stubout`/`stubout_class` raising `AttributeError` when given a string object path together with a separate `attr_name`


### PR DESCRIPTION
Finalizes the changelog for the 1.5.0 release by renaming `## Unreleased` to `## 1.5.0`.

Once merged, the `v1.5.0` tag will be cut from `main` and the final release published to PyPI. The release candidate (`1.5.0rc1`) has been validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)