### PR TITLE
Add `import pymox` alias and ship py.typed with public-API type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   `import pymox` now works and refers to the exact same package as `import mox` (`pymox is mox`), fixing the long-standing mismatch between the PyPI/distribution name (`pymox`) and the import name (`mox`)
+-   The package now ships a `py.typed` marker and type hints on the public API (the `Mox` lifecycle methods, `stubout`/`stubout_class`, `@mox.patch`, and the module-level `replay`/`verify`/`reset`), so type checkers and editors pick up pymox's types
 -   Added `@mox.patch` (and `@mox.patch_class`) decorators for context-manager-free stubbing, à la `unittest.mock.patch`: the mock is injected as an argument, stubs are restored, and mocks are verified automatically on a passing test. Decorators stack and inject mocks top-to-bottom
 -   The pytest `mox` fixture is now functional: it yields a managed `Mox` (also exposing the module-level helpers and comparators), restores stubs, and verifies mocks automatically when a test passes - without masking a failing test's real error. `mox_verify` is kept as a backward-compatible alias
 -   `mox.replay(factory)` now also puts the instances a `stubout_class` factory produced into replay mode, so a factory can be replayed with a single call

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ pip install pymox
 ```
 <!-- end-install -->
 
+Both import names work and refer to the exact same package (`import pymox is import mox`):
+```python
+import mox      # the original import name
+import pymox    # same thing, matches the PyPI name
+```
+
 ## Cool Stuff
 
 <!-- new-elegant -->

--- a/mox/decorators.py
+++ b/mox/decorators.py
@@ -24,11 +24,14 @@ written (top to bottom)::
 # Python imports
 import functools
 import inspect
+from typing import Any, Callable, Optional, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
 
 
-def _apply(target, attr_name, use_mock_anything, klass, func):
+def _apply(target: Any, attr_name: Optional[str], use_mock_anything: bool, klass: bool, func: F) -> F:
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         # Internal imports
         from mox.mox import Mox
 
@@ -66,10 +69,10 @@ def _apply(target, attr_name, use_mock_anything, klass, func):
     except (TypeError, ValueError):  # pragma: no cover - exotic callables
         pass
 
-    return wrapper
+    return wrapper  # type: ignore[return-value]
 
 
-def patch(target, attr_name=None, *, use_mock_anything=False):
+def patch(target: Any, attr_name: Optional[str] = None, *, use_mock_anything: bool = False) -> Callable[[F], F]:
     """Stub out ``target.attr_name`` for the duration of the decorated test.
 
     Args:
@@ -83,19 +86,19 @@ def patch(target, attr_name=None, *, use_mock_anything=False):
     The created mock is passed to the test as an extra positional argument.
     """
 
-    def decorator(func):
+    def decorator(func: F) -> F:
         return _apply(target, attr_name, use_mock_anything, False, func)
 
     return decorator
 
 
-def patch_class(target, attr_name=None):
+def patch_class(target: Any, attr_name: Optional[str] = None) -> Callable[[F], F]:
     """Like :func:`patch`, but replaces a class with a mock factory.
 
     See ``Mox.stubout_class`` for the factory semantics.
     """
 
-    def decorator(func):
+    def decorator(func: F) -> F:
         return _apply(target, attr_name, False, True, func)
 
     return decorator

--- a/mox/decorators.py
+++ b/mox/decorators.py
@@ -26,6 +26,7 @@ import functools
 import inspect
 from typing import Any, Callable, Optional, TypeVar
 
+
 F = TypeVar("F", bound=Callable[..., Any])
 
 

--- a/mox/mox.py
+++ b/mox/mox.py
@@ -65,6 +65,7 @@ import inspect
 import types
 from collections import deque
 from re import search as re_search
+from typing import Any, Optional
 
 from . import stubbingout
 from .comparators import IsA
@@ -117,7 +118,7 @@ class _MoxManagerMeta(type):
         for mox_instance in list(cls._instances.values()):
             mox_instance.verify_all()
 
-    def forget(cls, instance):
+    def forget(cls, instance: "Mox") -> None:
         """Drop a single Mox instance from the global registry.
 
         Used by the scoped entry points (the ``@mox.patch`` decorator and the
@@ -155,7 +156,7 @@ class Mox(metaclass=_MoxManagerMeta):
         self._mock_objects = []
         self.stubs = stubbingout.StubOutForTesting()
 
-    def create_mock(self, class_to_mock, attrs=None):
+    def create_mock(self, class_to_mock: Any, attrs: Optional[dict] = None) -> "MockObject":
         """Create a new mock object.
 
         Args:
@@ -173,7 +174,7 @@ class Mox(metaclass=_MoxManagerMeta):
         self._mock_objects.append(new_mock)
         return new_mock
 
-    def create_mock_anything(self, description=None):
+    def create_mock_anything(self, description: Optional[str] = None) -> "MockAnything":
         """Create a mock that will accept any method calls.
 
         This does not enforce an interface.
@@ -193,13 +194,13 @@ class Mox(metaclass=_MoxManagerMeta):
 
         return Expect.from_mox(mox_obj=self)
 
-    def replay_all(self):
+    def replay_all(self) -> None:
         """Set all mock objects to replay mode."""
 
         for mock_obj in self._mock_objects:
             mock_obj._replay()
 
-    def verify_all(self):
+    def verify_all(self) -> None:
         """Call verify on all mock objects created."""
 
         exceptions_thrown = []
@@ -213,14 +214,14 @@ class Mox(metaclass=_MoxManagerMeta):
             self.unset_stubs()
             raise exceptions_thrown[0]
 
-    def reset_all(self):
+    def reset_all(self) -> None:
         """Call reset on all mock objects.  This does not unset stubs."""
 
         for mock_obj in self._mock_objects:
             mock_obj._reset()
 
     @resolve_object
-    def stubout(self, obj, attr_name, use_mock_anything=False):
+    def stubout(self, obj: Any, attr_name: str, use_mock_anything: bool = False) -> Any:
         """Replace a method, attribute, etc. with a Mock.
 
         By default the attribute is replaced with a MockObject mirroring the
@@ -250,7 +251,7 @@ class Mox(metaclass=_MoxManagerMeta):
         return stub
 
     @resolve_object
-    def stubout_class(self, obj, attr_name):
+    def stubout_class(self, obj: Any, attr_name: str) -> "_MockObjectFactory":
         """Replace a class with a "mock factory" that will create mock objects.
 
         This is useful if the code-under-test directly instantiates
@@ -301,7 +302,7 @@ class Mox(metaclass=_MoxManagerMeta):
         self.stubs.set(obj, attr_name, factory)
         return factory
 
-    def unset_stubs(self):
+    def unset_stubs(self) -> None:
         """Restore stubs to their original state."""
 
         self.stubs.unset_all()
@@ -317,7 +318,7 @@ class Mox(metaclass=_MoxManagerMeta):
     UnsetStubs = unset_stubs
 
 
-def replay(*args):
+def replay(*args: Any) -> None:
     """Put mocks into Replay mode.
 
     Args:
@@ -331,7 +332,7 @@ def replay(*args):
 Replay = replay
 
 
-def verify(*args):
+def verify(*args: Any) -> None:
     """Verify mocks.
 
     Args:
@@ -345,7 +346,7 @@ def verify(*args):
 Verify = verify
 
 
-def reset(*args):
+def reset(*args: Any) -> None:
     """Reset mocks.
 
     Args:

--- a/pymox/__init__.py
+++ b/pymox/__init__.py
@@ -1,0 +1,18 @@
+"""``import pymox`` alias for the ``mox`` package.
+
+The distribution is published on PyPI as ``pymox`` while the import package has
+always been ``mox``. That mismatch trips people up (``pip install pymox`` then
+``import pymox`` used to fail), so this thin alias makes ``import pymox`` resolve
+to the exact same module object as ``import mox`` - ``pymox is mox`` - and
+submodules such as ``pymox.testing.pytest_mox`` resolve to the ``mox`` ones too.
+"""
+
+# Python imports
+import sys
+
+# Internal imports
+import mox
+
+# Make `pymox` *be* `mox` so there is a single set of classes, a single global
+# Mox registry, and a single copy of the pytest plugin (no duplicate fixtures).
+sys.modules[__name__] = mox

--- a/pymox/__init__.py
+++ b/pymox/__init__.py
@@ -13,6 +13,7 @@ import sys
 # Internal imports
 import mox
 
+
 # Make `pymox` *be* `mox` so there is a single set of classes, a single global
 # Mox registry, and a single copy of the pytest plugin (no duplicate fixtures).
 sys.modules[__name__] = mox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,12 +68,12 @@ distance-dirty = "{next_version}-dev{distance}+{vcs}{rev}.d{build_date:%Y%m%d}"
 file = "mox/__version__.py"
 
 [tool.hatch.build.targets.sdist]
-packages = ["mox"]
-include = ["mox/**"]
+packages = ["mox", "pymox"]
+include = ["mox/**", "pymox/**"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["mox"]
-include = ["mox/**"]
+packages = ["mox", "pymox"]
+include = ["mox/**", "pymox/**"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/test/test_pymox_alias.py
+++ b/test/test_pymox_alias.py
@@ -1,0 +1,35 @@
+"""The ``pymox`` import name must mirror the ``mox`` package exactly."""
+
+# Internal imports
+import mox
+import mox.testing.pytest_mox  # noqa: F401  (ensure the submodule is loaded)
+
+
+def test_pymox_is_mox():
+    import pymox
+
+    assert pymox is mox
+
+
+def test_pymox_exposes_public_api():
+    import pymox
+
+    for name in ("Mox", "patch", "patch_class", "stubout", "expect", "create", "is_a", "replay", "verify"):
+        assert hasattr(pymox, name), name
+
+
+def test_pymox_submodules_resolve_to_mox():
+    import pymox
+
+    # Attribute access (the way code actually reaches submodules) returns the
+    # very same module objects as ``mox`` - so a single Mox registry and a
+    # single ``mox`` pytest fixture.
+    assert pymox.testing is mox.testing
+    assert pymox.testing.pytest_mox is mox.testing.pytest_mox
+
+
+def test_py_typed_marker_is_shipped():
+    import os
+
+    marker = os.path.join(os.path.dirname(mox.__file__), "py.typed")
+    assert os.path.exists(marker)

--- a/test/test_pymox_alias.py
+++ b/test/test_pymox_alias.py
@@ -6,12 +6,14 @@ import mox.testing.pytest_mox  # noqa: F401  (ensure the submodule is loaded)
 
 
 def test_pymox_is_mox():
+    # Internal imports
     import pymox
 
     assert pymox is mox
 
 
 def test_pymox_exposes_public_api():
+    # Internal imports
     import pymox
 
     for name in ("Mox", "patch", "patch_class", "stubout", "expect", "create", "is_a", "replay", "verify"):
@@ -19,6 +21,7 @@ def test_pymox_exposes_public_api():
 
 
 def test_pymox_submodules_resolve_to_mox():
+    # Internal imports
     import pymox
 
     # Attribute access (the way code actually reaches submodules) returns the
@@ -29,6 +32,7 @@ def test_pymox_submodules_resolve_to_mox():
 
 
 def test_py_typed_marker_is_shipped():
+    # Python imports
     import os
 
     marker = os.path.join(os.path.dirname(mox.__file__), "py.typed")


### PR DESCRIPTION
## What

Two user-facing quick wins (Batch 2 of the DX overhaul).

### 1. `import pymox` now works
The distribution is published on PyPI as `pymox`, but the import package has always been `mox` — so `pip install pymox; import pymox` raised `ModuleNotFoundError`. This adds a thin alias package (`pymox/__init__.py`) that makes `import pymox` resolve to the **exact same module object** as `import mox`:

```python
import mox
import pymox
assert pymox is mox          # True
from pymox import Mox, patch, stubout, expect, is_a   # all work
```

Because `pymox is mox`, there's a single set of classes, a single global Mox registry, and a single copy of the pytest plugin (no duplicate fixtures). The pytest plugin path remains `mox.testing.pytest_mox`.

### 2. Ships types (`py.typed` + hints)
Adds a `py.typed` marker and type hints on the public API people actually call — the `Mox` lifecycle methods, `stubout`/`stubout_class`, `@mox.patch`/`@mox.patch_class`, and the module-level `replay`/`verify`/`reset`. Editors and type checkers now pick up pymox's types, so the Mypy badge stops being decorative. Comparator constructors are left for a later annotation pass.

## Packaging

`pyproject.toml` now builds and ships both the `mox` and `pymox` packages plus the `py.typed` marker — verified in the built wheel:
```
mox/py.typed
pymox/__init__.py
```

## Tests

New `test/test_pymox_alias.py`: asserts `pymox is mox`, the public API is reachable, submodules resolve to the same objects via attribute access, and the `py.typed` marker is shipped.

Full suite: **471 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)