### PR TITLE
Type the comparators and complete the Ruff migration (drop isort)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,8 +12,7 @@ repos:
     - id: mixed-line-ending
     - id: requirements-txt-fixer
     - id: trailing-whitespace
-# Ruff replaces flake8 (lint) and black (format). Import sorting / section
-# headers are still owned by isort below (Ruff cannot emit those headers).
+# Ruff handles linting (flake8), formatting (black) and import sorting (isort).
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.12.0
   hooks:
@@ -30,7 +29,3 @@ repos:
       # bandit imports pbr at runtime but does not pull it into the hook's
       # isolated env on newer Python; install it explicitly.
       additional_dependencies: ['pbr']
-- repo: https://github.com/PyCQA/isort
-  rev: 5.13.2
-  hooks:
-    - id: isort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- Added type hints to all comparators (constructors and `equals`), so editors show real signatures for `mox.is_a`, `mox.str_contains`, `mox.func`, and friends
+- Tooling: Ruff now also handles import sorting, replacing isort; the `# Python imports` / `# Pip imports` / `# Internal imports` section-header comments have been dropped in favor of Ruff's standard grouping
 - Split the monolithic 4,600-line `test/mox_test.py` into focused per-concern modules (`test_comparators.py`, `test_mock_objects.py`, `test_mox.py`, `test_mox_testbase.py`, the context-manager variants, etc.) with shared fixtures in `mox_test_fixtures_helper.py`
 - Fixed the `mox.expect` singleton retaining `stubs`/`mox_obj` after a `with mox.expect(...)`: block, which could make a later bare `with mox.expect:` skip the global replay (a cross-test isolation bug previously masked by test-file ordering)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,9 +40,8 @@ regressing (CI enforces a Codecov threshold).
 ## Linting and formatting
 
 Linting and formatting are handled by [pre-commit](https://pre-commit.com):
-**Ruff** (replacing flake8 and black), **isort** (import ordering, including the
-`# Python imports` / `# Internal imports` section headers Ruff does not emit),
-and **bandit**.
+**Ruff** (linting, formatting, and import sorting — replacing flake8, black,
+and isort) and **bandit**.
 
 ```bash
 make lint      # run every hook in check mode (pre-commit run --all-files)
@@ -54,8 +53,8 @@ commit.
 
 ## Conventions
 
-- Keep imports grouped under the `# Python imports` / `# Pip imports` /
-  `# Internal imports` headers; isort maintains these automatically.
+- Imports are grouped (stdlib / third-party / first-party) and sorted by Ruff
+  automatically; just run `make format`.
 - Line length is 120.
 - Public-facing changes should add type hints and update `CHANGELOG.md` under
   `## Unreleased`.

--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,12 @@ test:  ## Run the test suite
 test-cov:  ## Run tests with branch coverage (as CI does)
 	pytest --cov=mox --cov-branch --cov-report=term-missing test
 
-lint:  ## Run all linters/formatters in check mode (Ruff + isort + bandit, via pre-commit)
+lint:  ## Run all linters/formatters in check mode (Ruff + bandit, via pre-commit)
 	pre-commit run --all-files
 
 format:  ## Auto-format and sort imports in place
-	ruff format mox pymox test tools
 	ruff check --fix mox pymox test tools
-	isort mox pymox test tools
+	ruff format mox pymox test tools
 
 clean:  ## Remove build/test artifacts
 	rm -rf build dist *.egg-info .pytest_cache .coverage coverage.xml

--- a/mox/comparators.py
+++ b/mox/comparators.py
@@ -1,4 +1,3 @@
-# Python imports
 import re
 from typing import Any, Callable, Iterable
 

--- a/mox/comparators.py
+++ b/mox/comparators.py
@@ -1,5 +1,6 @@
 # Python imports
 import re
+from typing import Any, Callable, Iterable
 
 from .exceptions import Error
 
@@ -27,7 +28,7 @@ class Comparator:
     mock_dao.RunQuery(StrContains('SELECT'), IsA(int))
     """
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Special equals method that all comparators must implement.
 
         Args:
@@ -36,13 +37,13 @@ class Comparator:
 
         raise NotImplementedError
 
-    def __eq__(self, rhs):
+    def __eq__(self, rhs: object) -> bool:
         return self.equals(rhs)
 
-    def __ne__(self, rhs):
+    def __ne__(self, rhs: object) -> bool:
         return not self.equals(rhs)
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         # __eq__ is overridden, which otherwise makes comparators unhashable in
         # Python 3.  Hash by identity so comparators can be used in sets/dicts.
         return id(self)
@@ -51,13 +52,13 @@ class Comparator:
 class Is(Comparator):
     """Comparison class used to check identity, instead of equality."""
 
-    def __init__(self, obj):
+    def __init__(self, obj: Any) -> None:
         self._obj = obj
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         return rhs is self._obj
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<is %r (%s)>" % (self._obj, id(self._obj))
 
 
@@ -69,7 +70,7 @@ class IsA(Comparator):
     mock_dao.Connect(IsA(DbConnectInfo))
     """
 
-    def __init__(self, class_name):
+    def __init__(self, class_name: Any) -> None:
         """Initialize IsA
 
         Args:
@@ -78,7 +79,7 @@ class IsA(Comparator):
 
         self._class_name = class_name
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Check to see if the RHS is an instance of class_name.
 
         Args:
@@ -96,7 +97,7 @@ class IsA(Comparator):
             # things like cStringIO.StringIO.
             return isinstance(rhs, type(self._class_name))
 
-    def _is_subclass(self, clazz):
+    def _is_subclass(self, clazz: Any) -> bool:
         """Check to see if the IsA comparators class is a subclass of clazz.
 
         Args:
@@ -113,7 +114,7 @@ class IsA(Comparator):
             # things like cStringIO.StringIO.
             return isinstance(clazz, type(self._class_name))
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "mox.IsA(%s) " % str(self._class_name)
 
     _IsSubClass = _is_subclass
@@ -126,7 +127,7 @@ class IsAlmost(Comparator):
     Example mock_dao.SetTimeout((IsAlmost(3.9)))
     """
 
-    def __init__(self, float_value, places=7):
+    def __init__(self, float_value: float, places: int = 7) -> None:
         """Initialize IsAlmost.
 
         Args:
@@ -137,7 +138,7 @@ class IsAlmost(Comparator):
         self._float_value = float_value
         self._places = places
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Check to see if RHS is almost equal to float_value
 
         Args:
@@ -154,7 +155,7 @@ class IsAlmost(Comparator):
             # number.
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self._float_value)
 
 
@@ -167,7 +168,7 @@ class StrContains(Comparator):
     mock_dao.RunQuery(StrContains('IN (1, 2, 4, 5)')).AndReturn(mock_result)
     """
 
-    def __init__(self, search_string):
+    def __init__(self, search_string: str) -> None:
         """Initialize.
 
         Args:
@@ -177,7 +178,7 @@ class StrContains(Comparator):
 
         self._search_string = search_string
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Check to see if the search_string is contained in the rhs string.
 
         Args:
@@ -193,7 +194,7 @@ class StrContains(Comparator):
         except Exception:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<str containing '%s'>" % self._search_string
 
 
@@ -203,7 +204,7 @@ class Regex(Comparator):
     This uses a given regular expression to determine equality.
     """
 
-    def __init__(self, pattern, flags=0):
+    def __init__(self, pattern: Any, flags: int = 0) -> None:
         """Initialize.
 
         Args:
@@ -215,7 +216,7 @@ class Regex(Comparator):
 
         self.regex = re.compile(pattern, flags=flags)
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Check to see if rhs matches regular expression pattern.
 
         Returns:
@@ -227,7 +228,7 @@ class Regex(Comparator):
         except Exception:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         pattern = self.regex.pattern
         if isinstance(pattern, bytes):
             pattern = pattern.decode()
@@ -245,7 +246,7 @@ class In(Comparator):
     mock_dao.GetUsersInfo(In('expectedUserName')).AndReturn(mock_result)
     """
 
-    def __init__(self, key):
+    def __init__(self, key: Any) -> None:
         """Initialize.
 
         Args:
@@ -254,7 +255,7 @@ class In(Comparator):
 
         self._key = key
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Check to see whether key is in rhs.
 
         Args:
@@ -269,7 +270,7 @@ class In(Comparator):
         except Exception:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<sequence or map containing '%s'>" % str(self._key)
 
 
@@ -280,7 +281,7 @@ class Not(Comparator):
       mock_dao.UpdateUsers(Not(ContainsKeyValue('stevepm', stevepm_user_info)))
     """
 
-    def __init__(self, predicate):
+    def __init__(self, predicate: "Comparator") -> None:
         """Initialize.
 
         Args:
@@ -291,7 +292,7 @@ class Not(Comparator):
             raise Error("predicate %r must be a Comparator." % predicate)
         self._predicate = predicate
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Check to see whether the predicate is False.
 
         Args:
@@ -306,7 +307,7 @@ class Not(Comparator):
         except Exception:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<not '%s'>" % self._predicate
 
 
@@ -317,7 +318,7 @@ class ContainsKeyValue(Comparator):
     mock_dao.UpdateUsers(ContainsKeyValue('stevepm', stevepm_user_info))
     """
 
-    def __init__(self, key, value):
+    def __init__(self, key: Any, value: Any) -> None:
         """Initialize.
 
         Args:
@@ -328,7 +329,7 @@ class ContainsKeyValue(Comparator):
         self._key = key
         self._value = value
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Check whether the given key/value pair is in the rhs dict.
 
         Returns:
@@ -340,7 +341,7 @@ class ContainsKeyValue(Comparator):
         except Exception:
             return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<map containing the entry '%s: %s'>" % (
             str(self._key),
             str(self._value),
@@ -355,7 +356,7 @@ class ContainsAttributeValue(Comparator):
     mock_dao.UpdateSomething(ContainsAttribute('stevepm', stevepm_user_info))
     """
 
-    def __init__(self, key, value):
+    def __init__(self, key: str, value: Any) -> None:
         """Initialize.
 
         Args:
@@ -366,7 +367,7 @@ class ContainsAttributeValue(Comparator):
         self._key = key
         self._value = value
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Check whether the given attribute has a matching value in the rhs
         object.
 
@@ -387,7 +388,7 @@ class SameElementsAs(Comparator):
     mock_dao.ProcessUsers(SameElementsAs('stevepm', 'salomaki'))
     """
 
-    def __init__(self, expected_seq):
+    def __init__(self, expected_seq: Iterable[Any]) -> None:
         """Initialize.
 
         Args:
@@ -396,7 +397,7 @@ class SameElementsAs(Comparator):
         # Store in case expected_seq is an iterator.
         self._expected_list = list(expected_seq)
 
-    def equals(self, actual_seq):
+    def equals(self, actual_seq: Any) -> bool:
         """Check to see whether actual_seq has same elements as expected_seq.
 
         Args:
@@ -416,6 +417,8 @@ class SameElementsAs(Comparator):
             # equality (in MethodSignatureChecker) and to invoke Comparators.
             return False
 
+        expected: Any
+        actual: Any
         try:
             expected = dict([(element, None) for element in self._expected_list])
             actual = dict([(element, None) for element in actual_list])
@@ -434,7 +437,7 @@ class SameElementsAs(Comparator):
         else:
             return set(actual_list) == set(self._expected_list)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<sequence with same elements as '%s'>" % self._expected_list
 
 
@@ -443,7 +446,7 @@ class And(Comparator):
     results.
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args: "Comparator") -> None:
         """Initialize.
 
         Args:
@@ -452,7 +455,7 @@ class And(Comparator):
 
         self._comparators = args
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Checks whether all Comparators are equal to rhs.
 
         Args:
@@ -468,7 +471,7 @@ class And(Comparator):
 
         return True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<AND %s>" % str(self._comparators)
 
 
@@ -477,7 +480,7 @@ class Or(Comparator):
     results.
     """
 
-    def __init__(self, *args):
+    def __init__(self, *args: "Comparator") -> None:
         """Initialize.
 
         Args:
@@ -486,7 +489,7 @@ class Or(Comparator):
 
         self._comparators = args
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Checks whether any Comparator is equal to rhs.
 
         Args:
@@ -502,7 +505,7 @@ class Or(Comparator):
 
         return False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<OR %s>" % str(self._comparators)
 
 
@@ -523,7 +526,7 @@ class Func(Comparator):
     mock_dao.DoSomething(Func(myParamValidator), true)
     """
 
-    def __init__(self, func):
+    def __init__(self, func: Callable[[Any], Any]) -> None:
         """Initialize.
 
         Args:
@@ -532,7 +535,7 @@ class Func(Comparator):
 
         self._func = func
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         """Test whether rhs passes the function test.
 
         rhs is passed into func.
@@ -546,7 +549,7 @@ class Func(Comparator):
 
         return self._func(rhs)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return str(self._func)
 
 
@@ -560,7 +563,7 @@ class IgnoreArg(Comparator):
     third. mymock.CastMagic(3, IgnoreArg(), 'disappear')
     """
 
-    def equals(self, unused_rhs):
+    def equals(self, unused_rhs: Any) -> bool:
         """Ignores arguments and returns True.
 
         Args:
@@ -572,7 +575,7 @@ class IgnoreArg(Comparator):
 
         return True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<IgnoreArg>"
 
 
@@ -583,21 +586,21 @@ class Value(Comparator):
     for example.
     """
 
-    def __init__(self):
-        self._value = None
+    def __init__(self) -> None:
+        self._value: Any = None
         self._has_value = False
 
-    def store_value(self, rhs):
+    def store_value(self, rhs: Any) -> None:
         self._value = rhs
         self._has_value = True
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         if not self._has_value:
             return False
         else:
             return rhs == self._value
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self._has_value:
             return "<Value %r>" % self._value
         else:
@@ -618,16 +621,16 @@ class Remember(Comparator):
     mock_dao.ReportUsers(users_list)
     """
 
-    def __init__(self, value_store):
+    def __init__(self, value_store: "Value") -> None:
         if not isinstance(value_store, Value):
             raise TypeError("value_store is not an instance of the Value class")
         self._value_store = value_store
 
-    def equals(self, rhs):
+    def equals(self, rhs: Any) -> bool:
         self._value_store.store_value(rhs)
         return True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Remember %d>" % id(self._value_store)
 
 

--- a/mox/contextmanagers.py
+++ b/mox/contextmanagers.py
@@ -20,7 +20,6 @@ create = Create()
 
 class Stubout:
     def __init__(self, *stub, _class=False):
-        # Internal imports
         import mox
 
         self.stubs = [stub] if stub else []
@@ -81,7 +80,6 @@ class Expect:
         self.mox_obj = mox_obj
 
     def __enter__(self):
-        # Internal imports
         import mox
 
         mox.reset(*self.stubs)
@@ -93,7 +91,6 @@ class Expect:
         return self.stubs
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        # Internal imports
         import mox
 
         try:

--- a/mox/decorators.py
+++ b/mox/decorators.py
@@ -21,7 +21,6 @@ written (top to bottom)::
         ...
 """
 
-# Python imports
 import functools
 import inspect
 from typing import Any, Callable, Optional, TypeVar
@@ -33,7 +32,6 @@ F = TypeVar("F", bound=Callable[..., Any])
 def _apply(target: Any, attr_name: Optional[str], use_mock_anything: bool, klass: bool, func: F) -> F:
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
-        # Internal imports
         from mox.mox import Mox
 
         m = Mox()

--- a/mox/exceptions.py
+++ b/mox/exceptions.py
@@ -1,4 +1,3 @@
-# Python imports
 import difflib
 
 

--- a/mox/helpers.py
+++ b/mox/helpers.py
@@ -1,9 +1,7 @@
-# Python imports
 import pkgutil
 import sys
 from functools import partial, wraps
 
-# Internal imports
 from mox.exceptions import ObjectResolutionError
 
 
@@ -44,13 +42,11 @@ def _resolve_name(name):  # pragma: no cover
     AttributeError - if a failure occurred when traversing the object hierarchy
                      within the imported package to get to the desired object.
     """
-    # Python imports
     import importlib
 
     global _NAME_PATTERN
     if _NAME_PATTERN is None:
         # Lazy import to speedup Python startup time
-        # Python imports
         import re
 
         dotted_words = r"(?!\d)(\w+)(\.(?!\d)(\w+))*"

--- a/mox/mox.py
+++ b/mox/mox.py
@@ -61,7 +61,6 @@ Suggested usage / workflow:
   my_mox.verify_all()
 """
 
-# Python imports
 import inspect
 import types
 from collections import deque
@@ -190,7 +189,6 @@ class Mox(metaclass=_MoxManagerMeta):
 
     @property
     def expect(self):
-        # Internal imports
         from mox.contextmanagers import Expect
 
         return Expect.from_mox(mox_obj=self)
@@ -478,7 +476,6 @@ class MockAnything:
 
     @property
     def _expect(self):
-        # Internal imports
         from mox.contextmanagers import Expect
 
         return Expect(self)

--- a/mox/stubbingout.py
+++ b/mox/stubbingout.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Python imports
 import contextlib
 import inspect
 

--- a/mox/testing/pytest_mox.py
+++ b/mox/testing/pytest_mox.py
@@ -1,4 +1,3 @@
-# Pip imports
 import pytest
 
 
@@ -19,7 +18,6 @@ class _MoxFixture:
         try:
             return getattr(self._mox, name)
         except AttributeError:
-            # Internal imports
             import mox
 
             return getattr(mox, name)
@@ -41,7 +39,6 @@ def mox(request):
     Stubs are always restored when the test finishes. On a passing test the
     mocks are verified automatically, so no explicit ``verify`` call is needed.
     """
-    # Internal imports
     from mox import Mox
 
     mox_obj = Mox()
@@ -86,7 +83,6 @@ def pytest_runtest_teardown(item):
     """
     yield
 
-    # Internal imports
     import mox
 
     try:

--- a/mox/testing/unittest_mox.py
+++ b/mox/testing/unittest_mox.py
@@ -1,4 +1,3 @@
-# Python imports
 import unittest
 
 
@@ -42,7 +41,6 @@ class MoxMetaTestBase(type):
         Returns:
           The modified method.
         """
-        # Internal imports
         from mox import Mox, stubbingout
 
         def new_method(self, *args, **kwargs):
@@ -92,7 +90,6 @@ class MoxTestBase(_MoxTestBase):  # type: ignore[valid-type,misc]  # base built 
     """
 
     def setUp(self):
-        # Internal imports
         from mox import Mox, stubbingout
 
         super().setUp()

--- a/pymox/__init__.py
+++ b/pymox/__init__.py
@@ -7,10 +7,8 @@ to the exact same module object as ``import mox`` - ``pymox is mox`` - and
 submodules such as ``pymox.testing.pytest_mox`` resolve to the ``mox`` ones too.
 """
 
-# Python imports
 import sys
 
-# Internal imports
 import mox
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dev = [
 lint = [
     "pre-commit>=3.5",
     "ruff>=0.12,<0.13",
-    "isort>=5.13,<6",
     "mypy>=1.8",
 ]
 
@@ -104,44 +103,23 @@ exclude = ['mox/__version__\.py']
 [tool.ruff]
 line-length = 120
 target-version = "py310"
-# Ruff replaces black (formatting) and flake8 (linting). Import sorting and its
-# "# Python imports" / "# Internal imports" section headers are still handled by
-# isort below, because Ruff's import sorter does not emit those header comments.
+# Ruff handles linting (flake8), formatting (black) and import sorting (isort).
 extend-exclude = ["mox/__version__.py"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W"]
+# E/W: pycodestyle, F: pyflakes, I: isort.
+select = ["E", "F", "W", "I"]
 # E203 (whitespace before ':') conflicts with how the formatter spaces slices.
 ignore = ["E203"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["mox", "pymox"]
+lines-after-imports = 2
 
 [tool.ruff.format]
 # Keep the existing double-quote, trailing-comma style black produced.
 quote-style = "double"
 
-
-[tool.isort]
-atomic = true
-case_sensitive = true
-filter_files = true
-import_heading_firstparty = "Internal imports"
-import_heading_stdlib = "Python imports"
-import_heading_thirdparty = "Pip imports"
-known_startup = [
-  "startup",
-]
-line_length = 120
-lines_after_imports = 2
-profile = "black"
-py_version = "auto"
-remove_redundant_aliases = true
-sections = [
-  "FUTURE",
-  "STARTUP",
-  "STDLIB",
-  "THIRDPARTY",
-  "FIRSTPARTY",
-  "LOCALFOLDER",
-]
 
 [tool.bandit.assert_used]
 excludes = ['*_test.py', '*/test_*.py']

--- a/test/mox_test_fixtures_helper.py
+++ b/test/mox_test_fixtures_helper.py
@@ -17,7 +17,6 @@
 # limitations under the License.
 """Shared fixture classes used across the split mox test modules."""
 
-# Python imports
 import re
 
 

--- a/test/mox_test_helper.py
+++ b/test/mox_test_helper.py
@@ -25,12 +25,10 @@ mox_test.py test suite.
 See mox_test.MoxTestBaseTest for how this class is actually used.
 """
 
-# Python imports
 import abc
 import os
 import re
 
-# Internal imports
 import mox
 
 

--- a/test/mox_test_string_imports.py
+++ b/test/mox_test_string_imports.py
@@ -1,10 +1,7 @@
-# Python imports
 import re
 
-# Pip imports
 import pytest
 
-# Internal imports
 import mox
 
 from . import mox_test_helper

--- a/test/pytest_mox_test.py
+++ b/test/pytest_mox_test.py
@@ -1,7 +1,5 @@
-# Python imports
 import unittest
 
-# Internal imports
 import mox
 from mox.testing import pytest_mox
 

--- a/test/stubout_test.py
+++ b/test/stubout_test.py
@@ -14,10 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Python imports
 import unittest
 
-# Internal imports
 import mox
 from mox import stubbingout
 

--- a/test/test_comparators.py
+++ b/test/test_comparators.py
@@ -17,12 +17,10 @@
 # limitations under the License.
 """Tests for mox comparators."""
 
-# Python imports
 import io
 import re
 import unittest
 
-# Internal imports
 import mox
 
 

--- a/test/test_exceptions.py
+++ b/test/test_exceptions.py
@@ -17,10 +17,8 @@
 # limitations under the License.
 """Tests for mox exception types."""
 
-# Python imports
 import unittest
 
-# Internal imports
 import mox
 
 

--- a/test/test_mock_object_contextmanager.py
+++ b/test/test_mock_object_contextmanager.py
@@ -17,10 +17,8 @@
 # limitations under the License.
 """Tests for MockObject via the context-manager API."""
 
-# Python imports
 import unittest
 
-# Internal imports
 import mox
 
 from . import mox_test_helper

--- a/test/test_mock_objects.py
+++ b/test/test_mock_objects.py
@@ -17,13 +17,10 @@
 # limitations under the License.
 """Tests for MockMethod, MockAnything and MockObject (classic API)."""
 
-# Python imports
 import unittest
 
-# Pip imports
 import pytest
 
-# Internal imports
 import mox
 
 from . import mox_test_helper

--- a/test/test_mox.py
+++ b/test/test_mox.py
@@ -17,12 +17,10 @@
 # limitations under the License.
 """Tests for the Mox manager (classic API) and replay/verify/reset."""
 
-# Python imports
 import re
 import sys
 import unittest
 
-# Internal imports
 import mox
 
 from . import mox_test_helper
@@ -852,7 +850,6 @@ class MoxTest(unittest.TestCase):
         self.assertEqual("meta", one.x)
 
     try:
-        # Python imports
         import abc
 
         # I'd use the unittest skipping decorators for this but I want to

--- a/test/test_mox_contextmanager.py
+++ b/test/test_mox_contextmanager.py
@@ -17,14 +17,11 @@
 # limitations under the License.
 """Tests for the Mox manager via the context-manager API."""
 
-# Python imports
 import re
 import unittest
 
-# Pip imports
 import pytest
 
-# Internal imports
 import mox
 
 from . import mox_test_helper

--- a/test/test_mox_testbase.py
+++ b/test/test_mox_testbase.py
@@ -17,10 +17,8 @@
 # limitations under the License.
 """Tests for MoxTestBase and its variants."""
 
-# Python imports
 import unittest
 
-# Internal imports
 import mox
 
 from . import mox_test_helper

--- a/test/test_pymox_alias.py
+++ b/test/test_pymox_alias.py
@@ -1,19 +1,16 @@
 """The ``pymox`` import name must mirror the ``mox`` package exactly."""
 
-# Internal imports
 import mox
 import mox.testing.pytest_mox  # noqa: F401  (ensure the submodule is loaded)
 
 
 def test_pymox_is_mox():
-    # Internal imports
     import pymox
 
     assert pymox is mox
 
 
 def test_pymox_exposes_public_api():
-    # Internal imports
     import pymox
 
     for name in ("Mox", "patch", "patch_class", "stubout", "expect", "create", "is_a", "replay", "verify"):
@@ -21,7 +18,6 @@ def test_pymox_exposes_public_api():
 
 
 def test_pymox_submodules_resolve_to_mox():
-    # Internal imports
     import pymox
 
     # Attribute access (the way code actually reaches submodules) returns the
@@ -32,7 +28,6 @@ def test_pymox_submodules_resolve_to_mox():
 
 
 def test_py_typed_marker_is_shipped():
-    # Python imports
     import os
 
     marker = os.path.join(os.path.dirname(mox.__file__), "py.typed")

--- a/test/test_pythonic_api.py
+++ b/test/test_pythonic_api.py
@@ -1,13 +1,10 @@
 """Tests for the context-manager-free entry points: the ``@mox.patch``
 decorator and the ``mox`` pytest fixture."""
 
-# Python imports
 import os
 
-# Pip imports
 import pytest
 
-# Internal imports
 import mox
 
 from . import mox_test_helper

--- a/tools/versioning.py
+++ b/tools/versioning.py
@@ -1,8 +1,6 @@
-# Python imports
 import pathlib
 import re
 
-# Pip imports
 from hatchling.metadata.core import ProjectMetadata
 from hatchling.plugin.manager import PluginManager
 


### PR DESCRIPTION
Two follow-ups from the DX overhaul, as two reviewable commits.

## Commit 1 — Type the comparators
Annotates every comparator: constructors (`is_a`, `str_contains`, `func`, `regex`, `contains_key_value`, …), `equals`, and the supporting `__eq__`/`__ne__`/`__hash__`/`__repr__`/`store_value`/`_is_subclass`. Editors now show real signatures for the comparator factories, and the package stays mypy-clean (one local annotation added in `SameElementsAs.equals`, whose body mypy now checks).

## Commit 2 — Complete the Ruff migration (drop isort)
Batch 3 kept isort solely for its `# Python imports` / `# Pip imports` / `# Internal imports` section-header comments, which Ruff can't emit. This finishes the job:
- Enables Ruff's import sorter (`I` rule) with `known-first-party = ["mox", "pymox"]`.
- **Removes isort entirely** — the pre-commit hook, the `lint` extra, and `[tool.isort]`.
- **Strips the section-header comments repo-wide** (61 lines) in favor of Ruff's standard stdlib / third-party / first-party grouping.
- Updates `make format`, the pre-commit comment, and `CONTRIBUTING.md`.

Pure mechanical reformat — imports re-grouped/sorted by Ruff, no code changes. The result is idempotent under `ruff check` + `ruff format`.

## Result
Full suite: **472 passed**; mypy clean; `pre-commit run --all-files` clean (one fewer tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)